### PR TITLE
reduce chances of deadlock during caller init

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ let axiom: tracing_axiom::Axiom =
 
 let subscriber = tracing_subscriber::registry()
     .with(tracing_subscriber::fmt::layer())
-    .with(tracing_axiom::layer(axiom.evt_tx.clone()));
+    .with(tracing_axiom::layer(axiom.evt_tx.clone().downgrade()));
 tracing::subscriber::set_global_default(subscriber).unwrap();
 
 // Don't forget to deinit! Drop will panic! (if not panicking already)

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -42,7 +42,7 @@ async fn main() {
                 .parse_lossy(std::env::var("RUST_LOG").unwrap_or_default()),
         )
         .with(tracing_subscriber::fmt::layer())
-        .with(tracing_axiom::layer(axiom.evt_tx.clone()));
+        .with(tracing_axiom::layer(axiom.evt_tx.clone().downgrade()));
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
     async {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! let subscriber = tracing_subscriber::registry()
 //!     .with(tracing_subscriber::fmt::layer())
-//!     .with(tracing_axiom::layer(axiom.evt_tx.clone()));
+//!     .with(tracing_axiom::layer(axiom.evt_tx.clone().downgrade()));
 //! tracing::subscriber::set_global_default(subscriber).unwrap();
 //!
 //! // Don't forget to deinit! Drop will panic!
@@ -291,9 +291,9 @@ impl<X: Send> Drop for Axiom<X> {
 }
 
 pub fn layer<X>(
-    evt_tx: tokio::sync::mpsc::Sender<Event<X>>,
+    evt_tx: tokio::sync::mpsc::WeakSender<Event<X>>,
 ) -> layer::Layer<X> {
-    layer::Layer::<X> { sender: evt_tx.downgrade() }
+    layer::Layer::<X> { sender: evt_tx }
 }
 
 #[derive(serde::Serialize)]


### PR DESCRIPTION
i dont like tokio mpsc forcing us to use the type system for closing channels but this should make it less deadlocky footgunny