### PR TITLE
Impl sender pool and harden ingest retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,17 +461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,7 +479,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -1927,7 +1915,6 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
- "futures-util",
  "quanta",
  "rand",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -187,6 +231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -195,8 +240,22 @@ version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -204,6 +263,12 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
@@ -496,6 +561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +991,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -1537,6 +1620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +1925,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "bytes",
+ "clap",
  "criterion",
  "futures-util",
  "quanta",
@@ -1937,6 +2027,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -1825,6 +1837,7 @@ dependencies = [
  "axum",
  "bytes",
  "criterion",
+ "futures-util",
  "quanta",
  "rand",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,13 @@ system-proxy = ["reqwest/system-proxy"]
 
 [dependencies]
 bytes = "1.11.1"
-futures-util = "0.3.31"
 quanta = "0.12.0"
 rand = { version = "0.9.1", default-features = false, features = ["std", "alloc", "os_rng", "small_rng"] }
 reqwest = { version = "0.12.19", default-features = false, features = ["http2", "rustls-tls-webpki-roots"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 time = { version = "^0.3.17", features = ["formatting", "serde"] }
-tokio = { version = "1.45.1", features = ["sync"] }
+tokio = { version = "1.45.1", features = ["macros", "sync"] }
 tracing = "0.1.41"
 tracing-core = "0.1.34"
 tracing-subscriber = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ system-proxy = ["reqwest/system-proxy"]
 
 [dependencies]
 bytes = "1.11.1"
+futures-util = "0.3.31"
 quanta = "0.12.0"
 rand = { version = "0.9.1", default-features = false, features = ["std", "alloc", "os_rng", "small_rng"] }
 reqwest = { version = "0.12.19", default-features = false, features = ["http2", "rustls-tls-webpki-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ zstd = "0.13.2"
 
 [dev-dependencies]
 axum = { version = "0.8.4", features = ["macros"] }
+clap = { version = "4.5.38", features = ["derive"] }
 criterion = "0.6.0"
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 tracing-mock = { version = "0.1.0-beta.1", features = ["tracing-subscriber"] }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ let axiom: tracing_axiom::Axiom =
         dataset: "example-dataset",
         collect_target: 4 << 10,
         collect_timeout: std::time::Duration::from_millis(500),
+        sender_pool_size: 1,
     });
 
 // NOTE: can clone `axiom.evt_tx` and send custom events to it as long as they

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ let axiom: tracing_axiom::Axiom =
     tracing_axiom::init(tracing_axiom::Config {
         evt_que_len: 4 << 10,
         service_name: "example-service",
-        base_url: "https://api.axiom.co".parse().unwrap(),
+        base_url: "https://us-east-1.aws.edge.axiom.co".parse().unwrap(),
         api_key: &api_key,
-        dataset: "example-dataset",
+        dataset_id: "example-dataset",
         collect_target: 4 << 10,
         collect_timeout: std::time::Duration::from_millis(500),
         sender_pool_size: 1,

--- a/examples/bench_ingest.rs
+++ b/examples/bench_ingest.rs
@@ -1,0 +1,256 @@
+use std::time::{Duration, Instant};
+
+use clap::Parser as _;
+use rand::SeedableRng as _;
+use rand::seq::SliceRandom as _;
+use tracing_subscriber::layer::SubscriberExt as _;
+
+#[derive(clap::Parser, Debug)]
+#[command(name = "bench_ingest")]
+struct Cli {
+    #[arg(long)]
+    api_key: String,
+    #[arg(long, default_value = "https://api.axiom.co")]
+    base_url: String,
+    #[arg(long)]
+    dataset: String,
+    #[arg(
+        long,
+        value_delimiter = ',',
+        default_values_t = [1, 2, 4, 8]
+    )]
+    pool_sizes: Vec<usize>,
+    #[arg(long, default_value_t = 256)]
+    batches: usize,
+    #[arg(long, default_value_t = 1024)]
+    collect_target: usize,
+    #[arg(long, default_value_t = 1)]
+    evt_que_len: usize,
+    #[arg(long, default_value_t = 250)]
+    collect_timeout_ms: u64,
+    #[arg(long, default_value_t = 128)]
+    payload_bytes: usize,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    assert!(!cli.pool_sizes.is_empty(), "--pool-sizes must not be empty");
+    assert!(cli.batches > 0, "--batches must be > 0");
+    assert!(cli.collect_target > 0, "--collect-target must be > 0");
+    assert!(cli.evt_que_len > 0, "--evt-que-len must be > 0");
+    assert!(
+        cli.pool_sizes.iter().all(|&pool| pool > 0),
+        "--pool-sizes values must be > 0",
+    );
+
+    let mut exec_order = cli.pool_sizes.clone();
+    exec_order.shuffle(&mut rand::rngs::SmallRng::from_os_rng());
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async move {
+        let payload: &'static str =
+            Box::leak("x".repeat(cli.payload_bytes).into_boxed_str());
+        let subscriber = tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::EnvFilter::builder()
+                    .with_default_directive(
+                        tracing_subscriber::filter::LevelFilter::INFO.into(),
+                    )
+                    .parse_lossy(std::env::var("RUST_LOG").unwrap_or_default()),
+            )
+            .with(tracing_subscriber::fmt::layer());
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+
+        eprintln!(
+            concat!(
+                "benching dataset={} base_url={} pools={:?} ",
+                "exec_order={:?} batches={} collect_target={} ",
+                "evt_que_len={} payload_bytes={}"
+            ),
+            cli.dataset,
+            cli.base_url,
+            cli.pool_sizes,
+            exec_order,
+            cli.batches,
+            cli.collect_target,
+            cli.evt_que_len,
+            cli.payload_bytes,
+        );
+
+        let mut obs = Vec::with_capacity(exec_order.len());
+        for (exec_idx, &pool_size) in exec_order.iter().enumerate() {
+            eprintln!("phase {} pool_size={} ...", exec_idx + 1, pool_size,);
+            obs.push(run_phase(&cli, payload, exec_idx, pool_size).await);
+        }
+
+        obs.sort_by_key(|phase| phase.pool_size);
+
+        print_phase_table(&obs);
+        println!();
+        print_pct_table(&obs);
+    });
+}
+
+async fn run_phase(
+    opts: &Cli,
+    payload: &'static str,
+    exec_idx: usize,
+    pool_size: usize,
+) -> PhaseObs {
+    let base_url: tracing_axiom::Url = opts.base_url.parse().unwrap();
+    let axiom = tracing_axiom::init(tracing_axiom::Config {
+        evt_que_len: opts.evt_que_len,
+        service_name: "bench-ingest",
+        base_url,
+        api_key: &opts.api_key,
+        dataset: &opts.dataset,
+        collect_target: opts.collect_target,
+        collect_timeout: Duration::from_millis(opts.collect_timeout_ms),
+        sender_pool_size: pool_size,
+    });
+
+    let mut enqueue_wait =
+        Vec::with_capacity(opts.batches * opts.collect_target);
+    let mut batch_enqueue = Vec::with_capacity(opts.batches);
+    let push_t0 = Instant::now();
+
+    for batch in 0..opts.batches {
+        let batch_t0 = Instant::now();
+        for evt in batch_evts(payload, exec_idx, batch, opts.collect_target) {
+            let evt_t0 = Instant::now();
+            axiom.evt_tx.send(evt).await.unwrap();
+            enqueue_wait.push(nanos(evt_t0.elapsed()));
+        }
+        batch_enqueue.push(nanos(batch_t0.elapsed()));
+    }
+
+    let push = push_t0.elapsed();
+    let drain_t0 = Instant::now();
+    axiom.deinit().await;
+    let drain = drain_t0.elapsed();
+
+    PhaseObs {
+        pool_size,
+        batches: opts.batches,
+        evts: opts.batches * opts.collect_target,
+        push,
+        drain,
+        enqueue_wait,
+        batch_enqueue,
+    }
+}
+
+fn batch_evts(
+    payload: &'static str,
+    exec_idx: usize,
+    batch: usize,
+    collect_target: usize,
+) -> impl Iterator<Item = tracing_axiom::Event<BenchEvt>> {
+    (0..collect_target as u64).map(move |seq| {
+        tracing_axiom::Event::Extra(BenchEvt {
+            exec_idx,
+            batch,
+            seq,
+            data: BenchData { payload },
+        })
+    })
+}
+
+fn print_phase_table(obs: &[PhaseObs]) {
+    println!("throughput summary");
+    println!(
+        "{:<6} {:>7} {:>9} {:>8} {:>11} {:>8} {:>11} {:>9}",
+        "pool",
+        "batches",
+        "events",
+        "push s",
+        "push ev/s",
+        "flush s",
+        "flush ev/s",
+        "drain ms",
+    );
+    for phase in obs {
+        let flush = phase.push + phase.drain;
+        println!(
+            "{:<6} {:>7} {:>9} {:>8.3} {:>11.0} {:>8.3} {:>11.0} {:>9.3}",
+            phase.pool_size,
+            phase.batches,
+            phase.evts,
+            phase.push.as_secs_f64(),
+            phase.evts as f64 / phase.push.as_secs_f64(),
+            flush.as_secs_f64(),
+            phase.evts as f64 / flush.as_secs_f64(),
+            phase.drain.as_secs_f64() * 1_000.0,
+        );
+    }
+}
+
+fn print_pct_table(obs: &[PhaseObs]) {
+    println!("enqueue pressure percentiles (ms)");
+    println!(
+        "{:<6} {:<14} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8}",
+        "pool", "metric", "n", "p1", "p5", "p50", "p95", "p99",
+    );
+    for phase in obs {
+        print_pct_row(phase.pool_size, "enqueue_wait", &phase.enqueue_wait);
+        print_pct_row(phase.pool_size, "batch_enqueue", &phase.batch_enqueue);
+    }
+}
+
+fn print_pct_row(pool_size: usize, metric: &str, samples: &[u64]) {
+    println!(
+        "{:<6} {:<14} {:>8} {:>8.3} {:>8.3} {:>8.3} {:>8.3} {:>8.3}",
+        pool_size,
+        metric,
+        samples.len(),
+        ns_to_ms(pct(samples, 1)),
+        ns_to_ms(pct(samples, 5)),
+        ns_to_ms(pct(samples, 50)),
+        ns_to_ms(pct(samples, 95)),
+        ns_to_ms(pct(samples, 99)),
+    );
+}
+
+fn pct(samples: &[u64], pct: usize) -> u64 {
+    assert!(!samples.is_empty());
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let rank = (pct * sorted.len()).div_ceil(100).max(1) - 1;
+    sorted[rank]
+}
+
+fn ns_to_ms(ns: u64) -> f64 {
+    ns as f64 / 1_000_000.0
+}
+
+fn nanos(dur: Duration) -> u64 {
+    dur.as_nanos().try_into().unwrap()
+}
+
+#[derive(Debug)]
+struct PhaseObs {
+    pool_size: usize,
+    batches: usize,
+    evts: usize,
+    push: Duration,
+    drain: Duration,
+    enqueue_wait: Vec<u64>,
+    batch_enqueue: Vec<u64>,
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+struct BenchEvt {
+    exec_idx: usize,
+    batch: usize,
+    seq: u64,
+    data: BenchData,
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+struct BenchData {
+    payload: &'static str,
+}

--- a/examples/bench_ingest.rs
+++ b/examples/bench_ingest.rs
@@ -10,10 +10,10 @@ use tracing_subscriber::layer::SubscriberExt as _;
 struct Cli {
     #[arg(long)]
     api_key: String,
-    #[arg(long, default_value = "https://api.axiom.co")]
+    #[arg(long, default_value = "https://us-east-1.aws.edge.axiom.co")]
     base_url: String,
     #[arg(long)]
-    dataset: String,
+    dataset_id: String,
     #[arg(
         long,
         value_delimiter = ',',
@@ -71,7 +71,7 @@ fn main() {
                 "exec_order={:?} batches={} collect_target={} ",
                 "evt_que_len={} payload_bytes={}"
             ),
-            cli.dataset,
+            cli.dataset_id,
             cli.base_url,
             cli.pool_sizes,
             exec_order,
@@ -107,7 +107,7 @@ async fn run_phase(
         service_name: "bench-ingest",
         base_url,
         api_key: &opts.api_key,
-        dataset: &opts.dataset,
+        dataset_id: &opts.dataset_id,
         collect_target: opts.collect_target,
         collect_timeout: Duration::from_millis(opts.collect_timeout_ms),
         sender_pool_size: pool_size,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -27,9 +27,9 @@ async fn main() {
         tracing_axiom::init(tracing_axiom::Config {
             evt_que_len: 4 << 10,
             service_name: "example-service",
-            base_url: "https://api.axiom.co".parse().unwrap(),
+            base_url: "https://us-east-1.aws.edge.axiom.co".parse().unwrap(),
             api_key: &api_key,
-            dataset: "porting_test",
+            dataset_id: "porting_test",
             collect_target: 4 << 10,
             collect_timeout: std::time::Duration::from_millis(500),
             sender_pool_size: 1,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -32,6 +32,7 @@ async fn main() {
             dataset: "porting_test",
             collect_target: 4 << 10,
             collect_timeout: std::time::Duration::from_millis(500),
+            sender_pool_size: 1,
         });
 
     use tracing_subscriber::filter;

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -133,54 +133,31 @@ impl<X: serde::Serialize> Layer<X> {
         //       so that channel can be explicitly closed instead of
         //       relying solely on tx count.
         let Some(sender) = self.sender.upgrade() else {
-            fake_log_field(
-                "ERROR: queue closed. dropping event.",
-                "event",
-                &evt,
+            tracing::error!(
+                target: crate::INTERNAL_TARGET,
+                event = ?evt,
+                "queue closed. dropping event"
             );
             return;
         };
         match sender.try_send(evt) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Closed(e)) => {
-                fake_log_field(
-                    "ERROR: queue closed. dropping event.",
-                    "event",
-                    &e,
+                tracing::error!(
+                    target: crate::INTERNAL_TARGET,
+                    event = ?e,
+                    "queue closed. dropping event"
                 );
             }
             Err(mpsc::error::TrySendError::Full(e)) => {
-                fake_log_field(
-                    "ERROR: queue full. dropping event.",
-                    "event",
-                    &e,
+                tracing::error!(
+                    target: crate::INTERNAL_TARGET,
+                    event = ?e,
+                    "queue full. dropping event"
                 );
             }
         }
     }
-}
-
-fn fake_log_prefix(stderr: &mut impl std::io::Write, msg: &str) {
-    time::OffsetDateTime::now_utc()
-        .format_into(
-            &mut *stderr,
-            &time::format_description::well_known::Rfc3339,
-        )
-        .unwrap();
-    write!(&mut *stderr, " {}", msg).unwrap();
-}
-pub(crate) fn fake_log_field(
-    msg: &str,
-    k: &'static str,
-    v: &impl serde::Serialize,
-) {
-    use std::io::Write as _;
-    let mut stderr = std::io::stderr();
-
-    fake_log_prefix(&mut stderr, msg);
-    write!(&mut stderr, " {k}=").unwrap();
-    serde_json::ser::to_writer(&mut stderr, v).unwrap();
-    writeln!(&mut stderr).unwrap();
 }
 
 thread_local! {
@@ -303,6 +280,12 @@ impl<X: serde::Serialize + 'static, S: Subscriber + for<'a> LookupSpan<'a>>
         event: &tracing::Event<'_>,
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
+        // Internal ingest-task logs should go to the app's other tracing layers
+        // but must never be re-enqueued back into Axiom, or we'd recurse.
+        if event.metadata().target().starts_with(crate::INTERNAL_TARGET) {
+            return;
+        }
+
         let span = ctx.event_span(event);
 
         let (parent_span_id, trace_id, s_fields) = match span.and_then(|p| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,6 +522,151 @@ struct EventService<'a> {
     name: &'a str,
 }
 
+// Support team told me 1<<20 max per ndjson line
+const NDJSON_LINE_LEN_MAX: usize = 1 << 20;
+const WARN_JSON_LEN_MAX: usize = 2 << 10;
+const WARN_JSON_SUFFIX: &str = "...<truncated>";
+
+struct CountWrite<W> {
+    inner: W,
+    bytes: usize,
+}
+impl<W: std::io::Write> std::io::Write for CountWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let bytes = self.inner.write(buf)?;
+        self.bytes += bytes;
+        Ok(bytes)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+struct TruncWrite<'a> {
+    buf: &'a mut Vec<u8>,
+    limit: usize,
+    trunc: bool,
+}
+impl<'a> TruncWrite<'a> {
+    fn new(buf: &'a mut Vec<u8>, limit: usize) -> Self {
+        Self { buf, limit, trunc: false }
+    }
+}
+impl std::io::Write for TruncWrite<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let left = self.limit.saturating_sub(self.buf.len());
+        let keep = left.min(buf.len());
+        self.buf.extend_from_slice(&buf[..keep]);
+        self.trunc |= keep < buf.len();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn write_ndjson_line<W, X>(
+    writer: &mut W,
+    evt: &EventWrapper<'_, X>,
+) -> std::io::Result<usize>
+where
+    W: std::io::Write,
+    X: serde::Serialize,
+{
+    let mut writer = CountWrite { inner: writer, bytes: 0 };
+    serde_json::to_writer(&mut writer, evt).map_err(std::io::Error::other)?;
+    std::io::Write::write_all(&mut writer, b"\n")?;
+    Ok(writer.bytes)
+}
+
+fn warn_json_dump<'a, X>(
+    buf: &'a mut Vec<u8>,
+    evt: &EventWrapper<'_, X>,
+) -> Result<(&'a str, bool), serde_json::Error>
+where
+    X: serde::Serialize,
+{
+    buf.clear();
+
+    let limit = WARN_JSON_LEN_MAX.saturating_sub(WARN_JSON_SUFFIX.len());
+    let trunc = {
+        let mut writer = TruncWrite::new(buf, limit);
+        serde_json::to_writer(&mut writer, evt)?;
+        writer.trunc
+    };
+
+    let end = match std::str::from_utf8(buf) {
+        Ok(_) => buf.len(),
+        Err(err) => err.valid_up_to(),
+    };
+    buf.truncate(end);
+    if trunc {
+        buf.extend_from_slice(WARN_JSON_SUFFIX.as_bytes());
+    }
+    Ok((std::str::from_utf8(buf).unwrap(), trunc))
+}
+
+enum BatchCtl {
+    Continue,
+    DropBatch,
+    Shutdown,
+}
+
+fn encode_evt_line<W, X>(
+    encoder: &mut zstd::Encoder<'_, W>,
+    buf_warn_json: &mut Vec<u8>,
+    evt: &EventWrapper<'_, X>,
+    evts_count: usize,
+) -> BatchCtl
+where
+    W: std::io::Write,
+    X: serde::Serialize,
+{
+    let len = match write_ndjson_line(encoder, evt) {
+        Ok(bytes_line) => bytes_line,
+        Err(err) => {
+            tracing::error!(
+                target: INTERNAL_TARGET,
+                ?err,
+                evts_count,
+                "failed to encode event batch. dropping batch"
+            );
+            return BatchCtl::DropBatch;
+        }
+    };
+    if len > NDJSON_LINE_LEN_MAX {
+        match warn_json_dump(buf_warn_json, evt) {
+            Ok((event_json_truncated, event_json_was_truncated)) => {
+                tracing::warn!(
+                    target: INTERNAL_TARGET,
+                    len,
+                    bytes_limit = NDJSON_LINE_LEN_MAX,
+                    evts_count,
+                    event_json_truncated,
+                    event_json_was_truncated,
+                    "ndjson line exceeds limit"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: INTERNAL_TARGET,
+                    len,
+                    bytes_limit = NDJSON_LINE_LEN_MAX,
+                    evts_count,
+                    ?err,
+                    concat!(
+                        "ndjson line exceeds limit and warning ",
+                        "dump serialization failed"
+                    )
+                );
+            }
+        }
+    }
+    BatchCtl::Continue
+}
+
 #[derive(Default)]
 struct SenderSlot {
     /// Set by the coordinator, taken by exactly one sender task.
@@ -614,19 +759,12 @@ async fn coord_task<X>(
 ) where
     X: serde::Serialize + Send + 'static,
 {
-    use std::io::Write as _;
-
     use bytes::BufMut as _;
-
-    enum BatchCtl {
-        Continue,
-        DropBatch,
-        Shutdown,
-    }
 
     let mut zstd_ctx = zstd::zstd_safe::CCtx::try_create().unwrap();
     let mut body = bytes::BytesMut::with_capacity(2048);
     let mut evts_buf = Vec::with_capacity(collect_target);
+    let mut buf_warn_json = Vec::with_capacity(WARN_JSON_LEN_MAX);
     'batch: loop {
         let mut evts_count = 0;
 
@@ -653,28 +791,21 @@ async fn coord_task<X>(
                     rest -= read;
                     evts_count += read;
                     for evt in &evts_buf {
-                        if let Err(err) =
-                            serde_json::to_writer(&mut encoder, &EventWrapper {
-                                service: EventService { name: service_name },
-                                event: evt,
-                            })
-                        {
-                            tracing::error!(
-                                target: INTERNAL_TARGET,
-                                ?err,
-                                evts_count,
-                                "failed to encode event batch. dropping batch"
-                            );
-                            return BatchCtl::DropBatch;
-                        }
-                        if let Err(err) = encoder.write_all(b"\n") {
-                            tracing::error!(
-                                target: INTERNAL_TARGET,
-                                ?err,
-                                evts_count,
-                                "failed to encode event batch. dropping batch"
-                            );
-                            return BatchCtl::DropBatch;
+                        let evt = EventWrapper {
+                            service: EventService { name: service_name },
+                            event: evt,
+                        };
+                        match encode_evt_line(
+                            &mut encoder,
+                            &mut buf_warn_json,
+                            &evt,
+                            evts_count,
+                        ) {
+                            BatchCtl::Continue => {}
+                            BatchCtl::DropBatch => {
+                                return BatchCtl::DropBatch;
+                            }
+                            BatchCtl::Shutdown => unreachable!(),
                         }
                     }
                 }
@@ -947,7 +1078,10 @@ mod tests {
     };
     use serde::{Deserialize, Serialize};
 
-    use super::{Config, Event, init};
+    use super::{
+        Config, Event, EventService, EventWrapper, WARN_JSON_LEN_MAX,
+        WARN_JSON_SUFFIX, init, warn_json_dump, write_ndjson_line,
+    };
 
     #[derive(Clone)]
     struct ServerCfg {
@@ -975,6 +1109,8 @@ mod tests {
     #[derive(Deserialize, Serialize)]
     struct TestEvt {
         seq: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        payload: Option<String>,
     }
 
     #[derive(Default)]
@@ -1167,8 +1303,75 @@ mod tests {
 
     async fn send_evts(axiom: &super::Axiom<TestEvt>, count: u64) {
         for seq in 0..count {
-            axiom.evt_tx.send(Event::Extra(TestEvt { seq })).await.unwrap();
+            axiom
+                .evt_tx
+                .send(Event::Extra(TestEvt { seq, payload: None }))
+                .await
+                .unwrap();
         }
+    }
+
+    #[test]
+    fn ndjson_line_len_counts_bytes() {
+        let evt = EventWrapper {
+            service: EventService { name: "test-service" },
+            event: &Event::Extra(TestEvt { seq: 7, payload: None }),
+        };
+        let mut buf = Vec::new();
+
+        let bytes_line = write_ndjson_line(&mut buf, &evt).unwrap();
+
+        assert_eq!(bytes_line, buf.len());
+        assert_eq!(buf.last(), Some(&b'\n'));
+    }
+
+    #[test]
+    fn warn_json_dump_truncates_without_large_alloc() {
+        #[derive(Serialize)]
+        struct BigEvt<'a> {
+            seq: u64,
+            payload: &'a str,
+        }
+
+        static PAYLOAD: [u8; WARN_JSON_LEN_MAX * 2] =
+            [b'x'; WARN_JSON_LEN_MAX * 2];
+
+        let evt = Event::Extra(BigEvt {
+            seq: 7,
+            payload: std::str::from_utf8(&PAYLOAD).unwrap(),
+        });
+        let evt = EventWrapper {
+            service: EventService { name: "test-service" },
+            event: &evt,
+        };
+        let mut buf = Vec::with_capacity(WARN_JSON_LEN_MAX);
+
+        {
+            let (dump, trunc) = warn_json_dump(&mut buf, &evt).unwrap();
+
+            assert!(trunc);
+            assert_eq!(dump.len(), WARN_JSON_LEN_MAX);
+            assert!(dump.ends_with(WARN_JSON_SUFFIX));
+        }
+        assert_eq!(buf.len(), WARN_JSON_LEN_MAX);
+        assert!(buf.ends_with(WARN_JSON_SUFFIX.as_bytes()));
+    }
+
+    #[test]
+    fn warn_json_dump_clears_reused_buf() {
+        let evt = EventWrapper {
+            service: EventService { name: "test-service" },
+            event: &Event::Extra(TestEvt { seq: 7, payload: None }),
+        };
+        let mut buf = b"stale-bytes".to_vec();
+
+        {
+            let (dump, trunc) = warn_json_dump(&mut buf, &evt).unwrap();
+            assert!(!trunc);
+            assert!(!dump.contains("stale-bytes"));
+        }
+        assert!(!std::str::from_utf8(&buf).unwrap().contains("stale-bytes"));
+        assert!(!buf.windows("stale-bytes".len()).any(|s| s == b"stale-bytes"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1216,7 +1419,8 @@ mod tests {
 
         {
             let evt_tx = axiom.evt_tx.clone();
-            let send = evt_tx.send(Event::Extra(TestEvt { seq: 3 }));
+            let send =
+                evt_tx.send(Event::Extra(TestEvt { seq: 3, payload: None }));
             tokio::pin!(send);
             assert!(
                 tokio::time::timeout(Duration::from_millis(50), &mut send)
@@ -1360,7 +1564,9 @@ mod tests {
             S: serde::Serializer,
         {
             match self {
-                Self::Good(seq) => TestEvt { seq: *seq }.serialize(serializer),
+                Self::Good(seq) => {
+                    TestEvt { seq: *seq, payload: None }.serialize(serializer)
+                }
                 Self::Bad => Err(serde::ser::Error::custom("boom")),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,31 +789,27 @@ async fn send_blob(
                             }
                         }
                         Err(err) => {
-                            log_retry!(
-                                RetryErrKind::RespBodyParse,
+                            tracing::error!(
                                 target: INTERNAL_TARGET,
-                                ?backoff,
                                 attempt = attempts - 1,
                                 ?err,
                                 status = ?status_raw,
                                 evts_count = blob.evts_count,
-                                "failed to parse ingest response body"
+                                "failed to parse ingest response body. dropping blob"
                             );
-                            SendCtl::Retry
+                            SendCtl::Done
                         }
                     }
                 }
                 Err(err) => {
-                    log_retry!(
-                        RetryErrKind::RespBodyRead,
+                    tracing::error!(
                         target: INTERNAL_TARGET,
-                        ?backoff,
                         attempt = attempts - 1,
                         ?err,
                         evts_count = blob.evts_count,
-                        "failed to read ingest response body"
+                        "failed to read ingest response body. dropping blob"
                     );
-                    SendCtl::Retry
+                    SendCtl::Done
                 }
             },
             Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,15 +730,17 @@ async fn send_blob(
         Retry,
     }
 
-    // NOTE: this backoff is quite long. we currently bias this library to
-    // mainly if ever dropping events, doing so at the back of a full queue
-    // to allow for the queue to soften intermittent isues.
-    //
-    // for this reason we try to hold on to events and retry for a long time
-    // here.
+    // Mostly mirroring axiom-go's retry cfg and 5xx-only HTTP retry policy.
+    // Docs: https://pkg.go.dev/github.com/axiomhq/axiom-go/axiom
+    // Src: https://github.com/axiomhq/axiom-go/blob/main/axiom/client.go#L259
+    const INITIAL_BACKOFF: std::time::Duration =
+        std::time::Duration::from_millis(200);
+    const MAX_RETRY_ELAPSED: std::time::Duration =
+        std::time::Duration::from_secs(10);
     const BACKOFF_MULT: f32 = 1.5;
-    const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(3);
-    let mut backoff = std::time::Duration::from_millis(200);
+
+    let retry_start = tokio::time::Instant::now();
+    let mut backoff = INITIAL_BACKOFF;
     // NOTE: to avoid spamming logs and causing data loss due to truncation, we
     // only print the first of a repeated sequence of the same retry error.
     let mut last_err_kind = None;
@@ -753,9 +755,9 @@ async fn send_blob(
             last_err_kind = Some(kind);
         }};
     }
-    const MAX_RETRIES: u16 = 100;
-    let mut ctl = SendCtl::Retry;
-    for i in 0..MAX_RETRIES {
+    let mut attempts = 0u16;
+    let ctl = loop {
+        attempts += 1;
         let res = client
             .post(ingest_url.clone())
             .header(reqwest::header::AUTHORIZATION, bearer)
@@ -765,7 +767,7 @@ async fn send_blob(
             .send()
             .await
             .and_then(|resp| resp.error_for_status());
-        ctl = match res {
+        let ctl = match res {
             Ok(resp) => match resp.bytes().await {
                 Ok(status_raw) => {
                     match serde_json::from_slice::<IngestStatus>(&status_raw) {
@@ -776,7 +778,7 @@ async fn send_blob(
                                     RetryErrKind::IngestFailed,
                                     target: INTERNAL_TARGET,
                                     ?backoff,
-                                    attempt = i,
+                                    attempt = attempts - 1,
                                     status=?status_raw,
                                     evts_count = blob.evts_count,
                                     "axiom reported ingest failures"
@@ -791,7 +793,7 @@ async fn send_blob(
                                 RetryErrKind::RespBodyParse,
                                 target: INTERNAL_TARGET,
                                 ?backoff,
-                                attempt = i,
+                                attempt = attempts - 1,
                                 ?err,
                                 status = ?status_raw,
                                 evts_count = blob.evts_count,
@@ -806,7 +808,7 @@ async fn send_blob(
                         RetryErrKind::RespBodyRead,
                         target: INTERNAL_TARGET,
                         ?backoff,
-                        attempt = i,
+                        attempt = attempts - 1,
                         ?err,
                         evts_count = blob.evts_count,
                         "failed to read ingest response body"
@@ -815,35 +817,66 @@ async fn send_blob(
                 }
             },
             Err(err) => {
-                log_retry!(
-                    match err.status() {
-                        Some(status) => RetryErrKind::HttpStatus(status),
-                        None => RetryErrKind::Transport,
-                    },
-                    target: INTERNAL_TARGET,
-                    ?backoff,
-                    attempt = i,
-                    ?err,
-                    evts_count = blob.evts_count,
-                    "axiom request failed"
-                );
-                SendCtl::Retry
+                if err.is_connect() {
+                    log_retry!(
+                        RetryErrKind::Transport,
+                        target: INTERNAL_TARGET,
+                        ?backoff,
+                        attempt = attempts - 1,
+                        ?err,
+                        evts_count = blob.evts_count,
+                        "axiom connect failed"
+                    );
+                    SendCtl::Retry
+                // Axiom-go retries HTTP status >=500 here:
+                // https://github.com/axiomhq/axiom-go/blob/main/axiom/client.go#L277
+                } else if matches!(err.status(), Some(status) if status.is_server_error())
+                {
+                    log_retry!(
+                        RetryErrKind::HttpStatus(err.status().unwrap()),
+                        target: INTERNAL_TARGET,
+                        ?backoff,
+                        attempt = attempts - 1,
+                        ?err,
+                        evts_count = blob.evts_count,
+                        "axiom request failed"
+                    );
+                    SendCtl::Retry
+                } else {
+                    tracing::error!(
+                        target: INTERNAL_TARGET,
+                        attempt = attempts - 1,
+                        ?err,
+                        evts_count = blob.evts_count,
+                        "non-retryable axiom request failure. dropping blob"
+                    );
+                    SendCtl::Done
+                }
             }
         };
         match ctl {
-            SendCtl::Done => break,
+            SendCtl::Done => break SendCtl::Done,
             SendCtl::Retry => {
-                tokio::time::sleep(backoff).await;
-                backoff = backoff.mul_f32(BACKOFF_MULT).min(MAX_BACKOFF);
+                let Some(remaining) =
+                    MAX_RETRY_ELAPSED.checked_sub(retry_start.elapsed())
+                else {
+                    break SendCtl::Retry;
+                };
+                if remaining.is_zero() {
+                    break SendCtl::Retry;
+                }
+                tokio::time::sleep(backoff.min(remaining)).await;
+                backoff = backoff.mul_f32(BACKOFF_MULT);
             }
         }
-    }
+    };
     if matches!(ctl, SendCtl::Retry) {
         tracing::error!(
             target: INTERNAL_TARGET,
-            max_retries = MAX_RETRIES,
+            max_retry_elapsed_ms = MAX_RETRY_ELAPSED.as_millis(),
+            attempts,
             evts_count = blob.evts_count,
-            "reached max retries for ingest batch. dropping events!"
+            "reached retry deadline for ingest batch. dropping events!"
         );
     }
 }
@@ -913,6 +946,7 @@ mod tests {
     #[derive(Clone, Copy)]
     enum StubResp {
         Ok,
+        Http400,
         Http500,
         OkBadJson,
     }
@@ -1024,6 +1058,10 @@ mod tests {
         match resp {
             StubResp::Ok => (
                 axum::http::StatusCode::OK,
+                ingest_ok(req.evts).into_response(),
+            ),
+            StubResp::Http400 => (
+                axum::http::StatusCode::BAD_REQUEST,
                 ingest_ok(req.evts).into_response(),
             ),
             StubResp::Http500 => (
@@ -1175,6 +1213,22 @@ mod tests {
             obs.reqs.iter().map(|req| req.start_seq).collect::<Vec<_>>(),
             vec![0, 0, 1]
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ingest_http_400_does_not_retry() {
+        let srv = TestServer::new(ServerCfg {
+            delay: Duration::ZERO,
+            resps: vec![StubResp::Http400],
+        })
+        .await;
+        let axiom = srv.mk_axiom(8, 1, 1);
+
+        send_evts(&axiom, 1).await;
+        let obs = srv.finish(axiom).await;
+
+        assert_eq!(obs.reqs.len(), 1);
+        assert_eq!(obs.reqs[0].start_seq, 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,9 +740,6 @@ async fn send_blob(
     enum RetryErrKind {
         Transport,
         HttpStatus(reqwest::StatusCode),
-        RespBodyRead,
-        RespBodyParse,
-        IngestFailed,
     }
     enum SendCtl {
         Done,
@@ -967,6 +964,7 @@ mod tests {
         Ok,
         Http400,
         Http500,
+        Partial,
         OkBadJson,
     }
 
@@ -1060,6 +1058,20 @@ mod tests {
         }))
     }
 
+    fn ingest_partial(evts: usize) -> impl IntoResponse {
+        axum::Json(serde_json::json!({
+            "failed": 1,
+            "ingested": evts.saturating_sub(1),
+            "processedBytes": 0,
+            "failures": [{
+                "timestamp": "2026-03-19T00:00:00Z",
+                "error": "boom",
+            }],
+            "blocksCreated": null,
+            "walLength": null,
+        }))
+    }
+
     async fn ingest(
         State(stub): State<StubServer>,
         req: Request,
@@ -1087,6 +1099,10 @@ mod tests {
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                 ingest_ok(req.evts).into_response(),
             ),
+            StubResp::Partial => (
+                axum::http::StatusCode::OK,
+                ingest_partial(req.evts).into_response(),
+            ),
             StubResp::OkBadJson => {
                 (axum::http::StatusCode::OK, "nope".into_response())
             }
@@ -1095,6 +1111,11 @@ mod tests {
 
     impl TestServer {
         async fn new(cfg: ServerCfg) -> Self {
+            let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+            Self::new_at(cfg, addr).await
+        }
+
+        async fn new_at(cfg: ServerCfg, addr: SocketAddr) -> Self {
             let stub = StubServer {
                 resps: Arc::new(Mutex::new(
                     cfg.resps.iter().copied().collect(),
@@ -1105,12 +1126,7 @@ mod tests {
             let app = Router::new()
                 .route("/v1/ingest/test", post(ingest))
                 .with_state(stub.clone());
-            let listener = tokio::net::TcpListener::bind(SocketAddr::from((
-                [127, 0, 0, 1],
-                0,
-            )))
-            .await
-            .unwrap();
+            let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
             let addr = listener.local_addr().unwrap();
             let (shutdown_tx, shutdown_rx) =
                 tokio::sync::oneshot::channel::<()>();
@@ -1251,10 +1267,26 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn ingest_retries_malformed_success_body() {
+    async fn ingest_partial_does_not_retry() {
         let srv = TestServer::new(ServerCfg {
             delay: Duration::ZERO,
-            resps: vec![StubResp::OkBadJson],
+            resps: vec![StubResp::Partial],
+        })
+        .await;
+        let axiom = srv.mk_axiom(8, 1, 1);
+
+        send_evts(&axiom, 1).await;
+        let obs = srv.finish(axiom).await;
+
+        assert_eq!(obs.reqs.len(), 1);
+        assert_eq!(obs.reqs[0].start_seq, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ingest_http_500_retries() {
+        let srv = TestServer::new(ServerCfg {
+            delay: Duration::ZERO,
+            resps: vec![StubResp::Http500],
         })
         .await;
         let axiom = srv.mk_axiom(8, 1, 1);
@@ -1265,6 +1297,59 @@ mod tests {
         assert_eq!(obs.reqs.len(), 2);
         assert_eq!(obs.reqs[0].start_seq, 0);
         assert_eq!(obs.reqs[1].start_seq, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ingest_connect_retries() {
+        let addr = {
+            let listener = std::net::TcpListener::bind(SocketAddr::from((
+                [127, 0, 0, 1],
+                0,
+            )))
+            .unwrap();
+            let addr = listener.local_addr().unwrap();
+            drop(listener);
+            addr
+        };
+        let axiom = init(Config {
+            evt_que_len: 8,
+            service_name: "test-service",
+            base_url: format!("http://{}", addr).parse().unwrap(),
+            api_key: "test-key",
+            dataset_id: "test",
+            collect_target: 1,
+            collect_timeout: Duration::from_secs(30),
+            sender_pool_size: 1,
+        });
+
+        send_evts(&axiom, 1).await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        let srv = TestServer::new_at(
+            ServerCfg { delay: Duration::ZERO, resps: vec![] },
+            addr,
+        )
+        .await;
+        let obs = srv.finish(axiom).await;
+
+        assert_eq!(obs.reqs.len(), 1);
+        assert_eq!(obs.reqs[0].start_seq, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ingest_malformed_success_body_does_not_retry() {
+        let srv = TestServer::new(ServerCfg {
+            delay: Duration::ZERO,
+            resps: vec![StubResp::OkBadJson],
+        })
+        .await;
+        let axiom = srv.mk_axiom(8, 1, 1);
+
+        send_evts(&axiom, 1).await;
+        let obs = srv.finish(axiom).await;
+
+        assert_eq!(obs.reqs.len(), 1);
+        assert_eq!(obs.reqs[0].start_seq, 0);
     }
 
     #[derive(Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,13 +123,27 @@ where
             cfg.collect_timeout,
             cfg.service_name,
         );
-        let senders = futures_util::future::join_all(
-            slots.iter().enumerate().map(|(id, slot)| {
-                sender_task(id, slot, &idle_tx, &client, &ingest_url, &bearer)
-            }),
-        );
+        let senders = slots
+            .iter()
+            .enumerate()
+            .map(|(id, slot)| SenderFut {
+                done: false,
+                fut: sender_task(
+                    id,
+                    slot,
+                    &idle_tx,
+                    &client,
+                    &ingest_url,
+                    &bearer,
+                ),
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let mut senders = Box::into_pin(senders);
+        let senders =
+            std::future::poll_fn(|cx| poll_senders(senders.as_mut(), cx));
 
-        let ((), _senders) = futures_util::join!(coord, senders);
+        let ((), ()) = tokio::join!(coord, senders);
     };
     // Carry the caller's current dispatch onto the spawned bg task so its
     // internal logs still reach the app's other tracing layers.
@@ -506,6 +520,38 @@ struct BatchBlob {
     evts_count: usize,
 }
 
+struct SenderFut<F> {
+    done: bool,
+    fut: F,
+}
+
+fn poll_senders<F>(
+    mut senders: std::pin::Pin<&mut [SenderFut<F>]>,
+    cx: &mut std::task::Context<'_>,
+) -> std::task::Poll<()>
+where
+    F: std::future::Future<Output = ()>,
+{
+    let mut pending = false;
+
+    // SAFETY:
+    // `senders` is pinned once as a boxed slice and never moved again.
+    // We never reorder or replace elems, and only poll each future in place.
+    for sender in unsafe { senders.as_mut().get_unchecked_mut() }.iter_mut() {
+        if sender.done {
+            continue;
+        }
+
+        match unsafe { std::pin::Pin::new_unchecked(&mut sender.fut) }.poll(cx)
+        {
+            std::task::Poll::Ready(()) => sender.done = true,
+            std::task::Poll::Pending => pending = true,
+        }
+    }
+
+    if pending { std::task::Poll::Pending } else { std::task::Poll::Ready(()) }
+}
+
 async fn sender_task(
     id: usize,
     slot: &SenderSlot,
@@ -581,10 +627,13 @@ async fn coord_task<X>(
                     rest -= read;
                     evts_count += read;
                     for evt in &evts_buf {
-                        serde_json::to_writer(&mut encoder, &EventWrapper {
-                            service: EventService { name: service_name },
-                            event: evt,
-                        })
+                        serde_json::to_writer(
+                            &mut encoder,
+                            &EventWrapper {
+                                service: EventService { name: service_name },
+                                event: evt,
+                            },
+                        )
                         .unwrap();
                         encoder.write_all(b"\n").unwrap();
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,18 @@ pub fn init<X>(cfg: Config) -> Axiom<X>
 where
     X: serde::Serialize + std::marker::Send + 'static,
 {
+    // NOTE: mirror axiom-go's default client timeouts.
+    // Total timeout:
+    // https://github.com/axiomhq/axiom-go/blob/05ab863353532f691e2e46d72008d39897de3b6c/axiom/client.go#L61
+    // Transport timeouts:
+    // https://github.com/axiomhq/axiom-go/blob/05ab863353532f691e2e46d72008d39897de3b6c/axiom/client.go#L67
+    const TIMEOUT_REQ: std::time::Duration =
+        std::time::Duration::from_secs(300);
+    const TIMEOUT_CONNECT: std::time::Duration =
+        std::time::Duration::from_secs(30);
+    const TIMEOUT_READ: std::time::Duration =
+        std::time::Duration::from_secs(120);
+
     assert!(cfg.evt_que_len > 0, "evt_que_len must be > 0");
     assert!(cfg.collect_target > 0, "collect_target must be > 0");
     assert!(cfg.sender_pool_size > 0, "sender_pool_size must be > 0");
@@ -86,6 +98,9 @@ where
     )
     .unwrap();
     let client = reqwest::Client::builder()
+        .timeout(TIMEOUT_REQ)
+        .connect_timeout(TIMEOUT_CONNECT)
+        .read_timeout(TIMEOUT_READ)
         .user_agent(concat!(
             env!("CARGO_PKG_NAME"),
             "/",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@
 use std::borrow::Cow;
 
 pub use reqwest::Url;
-use tracing::instrument::WithSubscriber as _;
 
 pub mod layer;
 
@@ -145,9 +144,11 @@ where
 
         let ((), ()) = tokio::join!(coord, senders);
     };
-    // Carry the caller's current dispatch onto the spawned bg task so its
-    // internal logs still reach the app's other tracing layers.
-    let bg_handle = rt.spawn(bg_task.with_current_subscriber());
+    // NOTE: don't capture the caller's current dispatch here. In telm the
+    // global subscriber is installed after `init()`, so freezing the current
+    // dispatch would pin this bg task to the pre-init no-op subscriber and
+    // hide its internal logs from stderr/journal forever.
+    let bg_handle = rt.spawn(bg_task);
 
     Axiom { evt_tx: evt_tx.clone(), bg_handle: Some(bg_handle) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,8 @@ pub struct Config<'a> {
 
     /// Try to collect this many events before sending to axiom.
     ///
-    /// Keep this at or below 10_000. Axiom-go's `IngestChannel` uses 10_000 as
-    /// its batch size cap:
-    /// https://github.com/axiomhq/axiom-go/blob/05ab863353532f691e2e46d72008d39897de3b6c/axiom/client.go#L444-L446
+    /// Should be > 0 and <= 10_000
+    /// https://axiom.co/docs/reference/limits#limits-on-ingested-data
     pub collect_target: usize,
     /// If we didn't collect up to target after this duratiom, timeout and send
     /// what we have.
@@ -88,6 +87,8 @@ where
 
     assert!(cfg.evt_que_len > 0, "evt_que_len must be > 0");
     assert!(cfg.collect_target > 0, "collect_target must be > 0");
+    // See field doc-comment
+    assert!(cfg.collect_target <= 10_000, "collect_target must be <= 10_000");
     assert!(cfg.sender_pool_size > 0, "sender_pool_size must be > 0");
 
     let (evt_tx, mut evt_rx) = tokio::sync::mpsc::channel(cfg.evt_que_len);
@@ -652,13 +653,12 @@ async fn coord_task<X>(
                     rest -= read;
                     evts_count += read;
                     for evt in &evts_buf {
-                        if let Err(err) = serde_json::to_writer(
-                            &mut encoder,
-                            &EventWrapper {
+                        if let Err(err) =
+                            serde_json::to_writer(&mut encoder, &EventWrapper {
                                 service: EventService { name: service_name },
                                 event: evt,
-                            },
-                        ) {
+                            })
+                        {
                             tracing::error!(
                                 target: INTERNAL_TARGET,
                                 ?err,
@@ -787,27 +787,21 @@ async fn send_blob(
             Ok(resp) => match resp.bytes().await {
                 Ok(status_raw) => {
                     match serde_json::from_slice::<IngestStatus>(&status_raw) {
-                        Ok(status) => {
-                            if status.failed > 0 || !status.failures.is_empty()
-                            {
-                                // TODO: either get atomic ingest semantics
-                                // from axiom or track partial ingest and
-                                // resend only failed rows instead of dropping
-                                // the whole blob.
-                                tracing::error!(
-                                    target: INTERNAL_TARGET,
-                                    attempt = attempts - 1,
-                                    failed = status.failed,
-                                    ingested = status.ingested,
-                                    status=?status_raw,
-                                    evts_count = blob.evts_count,
-                                    "axiom reported partial ingest. dropping blob"
-                                );
-                                SendCtl::Done
-                            } else {
-                                SendCtl::Done
-                            }
+                        Ok(status)
+                            if status.failed > 0
+                                || !status.failures.is_empty() =>
+                        {
+                            tracing::error!(
+                                target: INTERNAL_TARGET,
+                                attempt = attempts - 1,
+                                failed = status.failed,
+                                ingested = status.ingested,
+                                status=?status_raw,
+                                evts_count = blob.evts_count,
+                                "axiom reported partial ingest."
+                            );
                         }
+                        Ok(_) => {}
                         Err(err) => {
                             tracing::error!(
                                 target: INTERNAL_TARGET,
@@ -815,11 +809,11 @@ async fn send_blob(
                                 ?err,
                                 status = ?status_raw,
                                 evts_count = blob.evts_count,
-                                "failed to parse ingest response body. dropping blob"
+                                "failed to parse ingest response body."
                             );
-                            SendCtl::Done
                         }
                     }
+                    SendCtl::Done
                 }
                 Err(err) => {
                     tracing::error!(
@@ -846,8 +840,10 @@ async fn send_blob(
                     SendCtl::Retry
                 // Axiom-go retries HTTP status >=500 here:
                 // https://github.com/axiomhq/axiom-go/blob/main/axiom/client.go#L277
-                } else if matches!(err.status(), Some(status) if status.is_server_error())
-                {
+                } else if matches!(
+                    err.status(),
+                    Some(status) if status.is_server_error()
+                ) {
                     log_retry!(
                         RetryErrKind::HttpStatus(err.status().unwrap()),
                         target: INTERNAL_TARGET,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ use tracing::instrument::WithSubscriber as _;
 
 pub mod layer;
 
+pub(crate) const INTERNAL_TARGET: &str = "tracing_axiom::internal";
+
 pub struct Config<'a> {
     pub api_key: &'a str,
     pub base_url: reqwest::Url,
@@ -78,10 +80,8 @@ where
     // NOTE: too much effort to bubble error here. this is run once on app init
     //       so this is fine. spurious crashlooping is impossible as the
     //       parsing is deterministic and config shouldn't be dynamic
-    let ingest_url = cfg
-        .base_url
-        .join(&format!("v1/ingest/{}", cfg.dataset_id))
-        .unwrap();
+    let ingest_url =
+        cfg.base_url.join(&format!("v1/ingest/{}", cfg.dataset_id)).unwrap();
     let bearer = reqwest::header::HeaderValue::try_from(
         format!("Bearer {}", cfg.api_key), //.
     )
@@ -129,10 +129,11 @@ where
             }),
         );
 
-        let ((), _senders) = tokio::join!(coord, senders);
+        let ((), _senders) = futures_util::join!(coord, senders);
     };
-    let bg_handle =
-        rt.spawn(bg_task.with_subscriber(tracing_core::Dispatch::none()));
+    // Carry the caller's current dispatch onto the spawned bg task so its
+    // internal logs still reach the app's other tracing layers.
+    let bg_handle = rt.spawn(bg_task.with_current_subscriber());
 
     Axiom { evt_tx: evt_tx.clone(), bg_handle: Some(bg_handle) }
 }
@@ -252,6 +253,27 @@ pub enum Event<Extra = Never> {
         kind: BogusKind,
     },
     Extra(Extra),
+}
+
+impl<Extra: serde::Serialize> std::fmt::Debug for Event<Extra> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        struct FmtIo<'a, 'b>(&'a mut std::fmt::Formatter<'b>);
+
+        impl std::io::Write for FmtIo<'_, '_> {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                let s =
+                    std::str::from_utf8(buf).map_err(std::io::Error::other)?;
+                self.0.write_str(s).map_err(std::io::Error::other)?;
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        serde_json::to_writer(FmtIo(f), self).map_err(|_| std::fmt::Error)
+    }
 }
 
 /// Axiom absolutely wants this for trace/span recognition so here it is.
@@ -551,10 +573,8 @@ async fn coord_task<X>(
                     let read = evt_rx.recv_many(&mut evts_buf, rest).await;
                     assert_eq!(read, evts_buf.len());
                     if read == 0 {
-                        if evts_count == 0 {
-                            if evts_buf.is_empty() {
-                                return Break(());
-                            }
+                        if evts_count == 0 && evts_buf.is_empty() {
+                            return Break(());
                         }
                         return Continue(());
                     }
@@ -638,6 +658,7 @@ async fn send_blob(
                     serde_json::from_slice(&status_raw).unwrap();
                 if status.failed > 0 || !status.failures.is_empty() {
                     tracing::error!(
+                        target: INTERNAL_TARGET,
                         ?backoff,
                         attempt = i,
                         status=?status_raw,
@@ -651,6 +672,7 @@ async fn send_blob(
             }
             Err(err) => {
                 tracing::error!(
+                    target: INTERNAL_TARGET,
                     ?backoff,
                     attempt = i,
                     ?err,
@@ -664,6 +686,7 @@ async fn send_blob(
     }
     if reached_max_retry {
         tracing::error!(
+            target: INTERNAL_TARGET,
             max_retries = MAX_RETRIES,
             evts_count = blob.evts_count,
             "reached max retries for ingest batch. dropping events!"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,13 +627,10 @@ async fn coord_task<X>(
                     rest -= read;
                     evts_count += read;
                     for evt in &evts_buf {
-                        serde_json::to_writer(
-                            &mut encoder,
-                            &EventWrapper {
-                                service: EventService { name: service_name },
-                                event: evt,
-                            },
-                        )
+                        serde_json::to_writer(&mut encoder, &EventWrapper {
+                            service: EventService { name: service_name },
+                            event: evt,
+                        })
                         .unwrap();
                         encoder.write_all(b"\n").unwrap();
                     }
@@ -687,8 +684,18 @@ async fn send_blob(
     bearer: &reqwest::header::HeaderValue,
     blob: BatchBlob,
 ) {
-    let mut backoff = std::time::Duration::from_millis(500);
+    // NOTE: this backoff is quite long. we currently bias this library to
+    // mainly if ever dropping events, doing so at the back of a full queue
+    // to allow for the queue to soften intermittent isues.
+    //
+    // for this reason we try to hold on to events and retry for a long time
+    // here.
+    const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(3);
+    let mut backoff = std::time::Duration::from_millis(200);
     let mut reached_max_retry = true;
+    // NOTE: to avoid spamming logs and causing data loss due to truncation, we
+    // only print the first of a repeated sequence of errors of each type.
+    let mut last_err_is_transport = None;
     const MAX_RETRIES: u16 = 100;
     for i in 0..MAX_RETRIES {
         let res = client
@@ -706,32 +713,56 @@ async fn send_blob(
                 let status: IngestStatus =
                     serde_json::from_slice(&status_raw).unwrap();
                 if status.failed > 0 || !status.failures.is_empty() {
-                    tracing::error!(
-                        target: INTERNAL_TARGET,
-                        ?backoff,
-                        attempt = i,
-                        status=?status_raw,
-                        evts_count = blob.evts_count,
-                        "axiom reported ingest failures"
-                    );
+                    if last_err_is_transport.unwrap_or(true) {
+                        tracing::error!(
+                            target: INTERNAL_TARGET,
+                            ?backoff,
+                            attempt = i,
+                            status=?status_raw,
+                            evts_count = blob.evts_count,
+                            "axiom reported ingest failures"
+                        );
+                    } else {
+                        tracing::warn!(
+                            target: INTERNAL_TARGET,
+                            ?backoff,
+                            attempt = i,
+                            status=?status_raw,
+                            evts_count = blob.evts_count,
+                            "axiom reported ingest failures"
+                        );
+                    }
+                    last_err_is_transport = Some(false);
                 } else {
                     reached_max_retry = false;
                     break;
                 }
             }
             Err(err) => {
-                tracing::error!(
-                    target: INTERNAL_TARGET,
-                    ?backoff,
-                    attempt = i,
-                    ?err,
-                    evts_count = blob.evts_count,
-                    "axiom request failed"
-                );
+                if !last_err_is_transport.unwrap_or(false) {
+                    tracing::error!(
+                        target: INTERNAL_TARGET,
+                        ?backoff,
+                        attempt = i,
+                        ?err,
+                        evts_count = blob.evts_count,
+                        "axiom request failed"
+                    );
+                } else {
+                    tracing::debug!(
+                        target: INTERNAL_TARGET,
+                        ?backoff,
+                        attempt = i,
+                        ?err,
+                        evts_count = blob.evts_count,
+                        "axiom request failed"
+                    );
+                }
+                last_err_is_transport = Some(true);
             }
         }
         tokio::time::sleep(backoff).await;
-        backoff = backoff.mul_f32(1.5);
+        backoff = backoff.mul_f32(1.5).min(MAX_BACKOFF);
     }
     if reached_max_retry {
         tracing::error!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@ pub fn init<X>(cfg: Config) -> Axiom<X>
 where
     X: serde::Serialize + std::marker::Send + 'static,
 {
-    if cfg.sender_pool_size == 0 {
-        panic!("sender_pool_size must be > 0");
-    }
+    assert!(cfg.evt_que_len > 0, "evt_que_len must be > 0");
+    assert!(cfg.collect_target > 0, "collect_target must be > 0");
+    assert!(cfg.sender_pool_size > 0, "sender_pool_size must be > 0");
 
     let (evt_tx, mut evt_rx) = tokio::sync::mpsc::channel(cfg.evt_que_len);
 
@@ -594,14 +594,19 @@ async fn coord_task<X>(
     X: serde::Serialize + Send + 'static,
 {
     use std::io::Write as _;
-    use std::ops::ControlFlow::{Break, Continue};
 
     use bytes::BufMut as _;
+
+    enum BatchCtl {
+        Continue,
+        DropBatch,
+        Shutdown,
+    }
 
     let mut zstd_ctx = zstd::zstd_safe::CCtx::try_create().unwrap();
     let mut body = bytes::BytesMut::with_capacity(2048);
     let mut evts_buf = Vec::with_capacity(collect_target);
-    loop {
+    'batch: loop {
         let mut evts_count = 0;
 
         body.clear();
@@ -620,30 +625,57 @@ async fn coord_task<X>(
                     assert_eq!(read, evts_buf.len());
                     if read == 0 {
                         if evts_count == 0 && evts_buf.is_empty() {
-                            return Break(());
+                            return BatchCtl::Shutdown;
                         }
-                        return Continue(());
+                        return BatchCtl::Continue;
                     }
                     rest -= read;
                     evts_count += read;
                     for evt in &evts_buf {
-                        serde_json::to_writer(&mut encoder, &EventWrapper {
-                            service: EventService { name: service_name },
-                            event: evt,
-                        })
-                        .unwrap();
-                        encoder.write_all(b"\n").unwrap();
+                        if let Err(err) = serde_json::to_writer(
+                            &mut encoder,
+                            &EventWrapper {
+                                service: EventService { name: service_name },
+                                event: evt,
+                            },
+                        ) {
+                            tracing::error!(
+                                target: INTERNAL_TARGET,
+                                ?err,
+                                evts_count,
+                                "failed to encode event batch. dropping batch"
+                            );
+                            return BatchCtl::DropBatch;
+                        }
+                        if let Err(err) = encoder.write_all(b"\n") {
+                            tracing::error!(
+                                target: INTERNAL_TARGET,
+                                ?err,
+                                evts_count,
+                                "failed to encode event batch. dropping batch"
+                            );
+                            return BatchCtl::DropBatch;
+                        }
                     }
                 }
-                Continue(())
+                BatchCtl::Continue
             })
             .await
             {
-                Ok(Break(())) => {
+                Ok(BatchCtl::Shutdown) => {
                     close_slots(slots).await;
                     return;
                 }
-                Ok(Continue(())) | Err(tokio::time::error::Elapsed { .. }) => {}
+                Ok(BatchCtl::DropBatch) => {
+                    drop(encoder);
+                    body = body_writer.into_inner();
+                    zstd_ctx
+                        .reset(zstd::zstd_safe::ResetDirective::SessionOnly)
+                        .unwrap();
+                    continue 'batch;
+                }
+                Ok(BatchCtl::Continue)
+                | Err(tokio::time::error::Elapsed { .. }) => {}
             };
         }
         assert!(evts_count > 0);
@@ -684,19 +716,44 @@ async fn send_blob(
     bearer: &reqwest::header::HeaderValue,
     blob: BatchBlob,
 ) {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum RetryErrKind {
+        Transport,
+        HttpStatus(reqwest::StatusCode),
+        RespBodyRead,
+        RespBodyParse,
+        IngestFailed,
+    }
+    enum SendCtl {
+        Done,
+        Retry,
+    }
+
     // NOTE: this backoff is quite long. we currently bias this library to
     // mainly if ever dropping events, doing so at the back of a full queue
     // to allow for the queue to soften intermittent isues.
     //
     // for this reason we try to hold on to events and retry for a long time
     // here.
+    const BACKOFF_MULT: f32 = 1.5;
     const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(3);
     let mut backoff = std::time::Duration::from_millis(200);
-    let mut reached_max_retry = true;
     // NOTE: to avoid spamming logs and causing data loss due to truncation, we
-    // only print the first of a repeated sequence of errors of each type.
-    let mut last_err_is_transport = None;
+    // only print the first of a repeated sequence of the same retry error.
+    let mut last_err_kind = None;
+    macro_rules! log_retry {
+        ($kind:expr, $($arg:tt)*) => {{
+            let kind = $kind;
+            if last_err_kind == Some(kind) {
+                tracing::debug!($($arg)*);
+            } else {
+                tracing::error!($($arg)*);
+            }
+            last_err_kind = Some(kind);
+        }};
+    }
     const MAX_RETRIES: u16 = 100;
+    let mut ctl = SendCtl::Retry;
     for i in 0..MAX_RETRIES {
         let res = client
             .post(ingest_url.clone())
@@ -707,64 +764,80 @@ async fn send_blob(
             .send()
             .await
             .and_then(|resp| resp.error_for_status());
-        match res {
-            Ok(resp) => {
-                let status_raw = resp.bytes().await.unwrap();
-                let status: IngestStatus =
-                    serde_json::from_slice(&status_raw).unwrap();
-                if status.failed > 0 || !status.failures.is_empty() {
-                    if last_err_is_transport.unwrap_or(true) {
-                        tracing::error!(
-                            target: INTERNAL_TARGET,
-                            ?backoff,
-                            attempt = i,
-                            status=?status_raw,
-                            evts_count = blob.evts_count,
-                            "axiom reported ingest failures"
-                        );
-                    } else {
-                        tracing::warn!(
-                            target: INTERNAL_TARGET,
-                            ?backoff,
-                            attempt = i,
-                            status=?status_raw,
-                            evts_count = blob.evts_count,
-                            "axiom reported ingest failures"
-                        );
+        ctl = match res {
+            Ok(resp) => match resp.bytes().await {
+                Ok(status_raw) => {
+                    match serde_json::from_slice::<IngestStatus>(&status_raw) {
+                        Ok(status) => {
+                            if status.failed > 0 || !status.failures.is_empty()
+                            {
+                                log_retry!(
+                                    RetryErrKind::IngestFailed,
+                                    target: INTERNAL_TARGET,
+                                    ?backoff,
+                                    attempt = i,
+                                    status=?status_raw,
+                                    evts_count = blob.evts_count,
+                                    "axiom reported ingest failures"
+                                );
+                                SendCtl::Retry
+                            } else {
+                                SendCtl::Done
+                            }
+                        }
+                        Err(err) => {
+                            log_retry!(
+                                RetryErrKind::RespBodyParse,
+                                target: INTERNAL_TARGET,
+                                ?backoff,
+                                attempt = i,
+                                ?err,
+                                status = ?status_raw,
+                                evts_count = blob.evts_count,
+                                "failed to parse ingest response body"
+                            );
+                            SendCtl::Retry
+                        }
                     }
-                    last_err_is_transport = Some(false);
-                } else {
-                    reached_max_retry = false;
-                    break;
                 }
-            }
+                Err(err) => {
+                    log_retry!(
+                        RetryErrKind::RespBodyRead,
+                        target: INTERNAL_TARGET,
+                        ?backoff,
+                        attempt = i,
+                        ?err,
+                        evts_count = blob.evts_count,
+                        "failed to read ingest response body"
+                    );
+                    SendCtl::Retry
+                }
+            },
             Err(err) => {
-                if !last_err_is_transport.unwrap_or(false) {
-                    tracing::error!(
-                        target: INTERNAL_TARGET,
-                        ?backoff,
-                        attempt = i,
-                        ?err,
-                        evts_count = blob.evts_count,
-                        "axiom request failed"
-                    );
-                } else {
-                    tracing::debug!(
-                        target: INTERNAL_TARGET,
-                        ?backoff,
-                        attempt = i,
-                        ?err,
-                        evts_count = blob.evts_count,
-                        "axiom request failed"
-                    );
-                }
-                last_err_is_transport = Some(true);
+                log_retry!(
+                    match err.status() {
+                        Some(status) => RetryErrKind::HttpStatus(status),
+                        None => RetryErrKind::Transport,
+                    },
+                    target: INTERNAL_TARGET,
+                    ?backoff,
+                    attempt = i,
+                    ?err,
+                    evts_count = blob.evts_count,
+                    "axiom request failed"
+                );
+                SendCtl::Retry
+            }
+        };
+        match ctl {
+            SendCtl::Done => break,
+            SendCtl::Retry => {
+                tokio::time::sleep(backoff).await;
+                backoff = backoff.mul_f32(BACKOFF_MULT).min(MAX_BACKOFF);
             }
         }
-        tokio::time::sleep(backoff).await;
-        backoff = backoff.mul_f32(1.5).min(MAX_BACKOFF);
     }
-    if reached_max_retry {
+    if matches!(ctl, SendCtl::Retry) {
         tracing::error!(
             target: INTERNAL_TARGET,
             max_retries = MAX_RETRIES,
@@ -813,7 +886,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::HashMap,
+        collections::VecDeque,
         net::SocketAddr,
         sync::{Arc, Mutex},
         time::Duration,
@@ -830,10 +903,17 @@ mod tests {
 
     use super::{Config, Event, init};
 
-    #[derive(Clone, Copy)]
+    #[derive(Clone)]
     struct ServerCfg {
         delay: Duration,
-        fail_first_batch_once: bool,
+        resps: Vec<StubResp>,
+    }
+
+    #[derive(Clone, Copy)]
+    enum StubResp {
+        Ok,
+        Http500,
+        OkBadJson,
     }
 
     #[derive(Clone, Debug)]
@@ -851,8 +931,6 @@ mod tests {
 
     #[derive(Default)]
     struct ServerObs {
-        /// Per-request attempt count for the retry test.
-        attempts: HashMap<u64, usize>,
         /// Request log in arrival order.
         reqs: Vec<ReqObs>,
         /// Current concurrent requests inside the stub server.
@@ -865,6 +943,8 @@ mod tests {
     struct StubServer {
         /// Static behavior knobs for this server instance.
         cfg: ServerCfg,
+        /// Scripted response sequence for this server instance.
+        resps: Arc<Mutex<VecDeque<StubResp>>>,
         /// Mutable observations shared with the tests.
         obs: Arc<Mutex<ServerObs>>,
     }
@@ -906,18 +986,13 @@ mod tests {
         ReqObs { start_seq: start_seq.unwrap(), evts }
     }
 
-    fn record_req(stub: &StubServer, req: &ReqObs) -> bool {
+    fn record_req(stub: &StubServer, req: &ReqObs) -> StubResp {
         let mut obs = stub.obs.lock().unwrap();
         obs.in_flight += 1;
         obs.max_in_flight = obs.max_in_flight.max(obs.in_flight);
         obs.reqs.push(req.clone());
-
-        let attempt = obs.attempts.entry(req.start_seq).or_insert(0);
-        let should_fail = stub.cfg.fail_first_batch_once
-            && req.start_seq == 0
-            && *attempt == 0;
-        *attempt += 1;
-        should_fail
+        drop(obs);
+        stub.resps.lock().unwrap().pop_front().unwrap_or(StubResp::Ok)
     }
 
     fn ingest_ok(evts: usize) -> impl IntoResponse {
@@ -937,7 +1012,7 @@ mod tests {
     ) -> impl IntoResponse {
         let req =
             decode_req(to_bytes(req.into_body(), usize::MAX).await.unwrap());
-        let should_fail = record_req(&stub, &req);
+        let resp = record_req(&stub, &req);
 
         if stub.cfg.delay > Duration::ZERO {
             tokio::time::sleep(stub.cfg.delay).await;
@@ -945,17 +1020,27 @@ mod tests {
 
         stub.obs.lock().unwrap().in_flight -= 1;
 
-        let status = if should_fail {
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR
-        } else {
-            axum::http::StatusCode::OK
-        };
-        (status, ingest_ok(req.evts))
+        match resp {
+            StubResp::Ok => (
+                axum::http::StatusCode::OK,
+                ingest_ok(req.evts).into_response(),
+            ),
+            StubResp::Http500 => (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                ingest_ok(req.evts).into_response(),
+            ),
+            StubResp::OkBadJson => {
+                (axum::http::StatusCode::OK, "nope".into_response())
+            }
+        }
     }
 
     impl TestServer {
         async fn new(cfg: ServerCfg) -> Self {
             let stub = StubServer {
+                resps: Arc::new(Mutex::new(
+                    cfg.resps.iter().copied().collect(),
+                )),
                 cfg,
                 obs: Arc::new(Mutex::new(ServerObs::default())),
             };
@@ -1020,7 +1105,7 @@ mod tests {
     async fn ingest_sender_pool_1_preserves_request_order() {
         let srv = TestServer::new(ServerCfg {
             delay: Duration::from_millis(50),
-            fail_first_batch_once: false,
+            resps: vec![],
         })
         .await;
         let axiom = srv.mk_axiom(8, 2, 1);
@@ -1037,7 +1122,7 @@ mod tests {
     async fn ingest_sender_pool_gt_1_allows_concurrent_sends() {
         let srv = TestServer::new(ServerCfg {
             delay: Duration::from_millis(150),
-            fail_first_batch_once: false,
+            resps: vec![],
         })
         .await;
         let axiom = srv.mk_axiom(8, 1, 2);
@@ -1052,7 +1137,7 @@ mod tests {
     async fn ingest_full_sender_pool_pushes_backpressure_upstream() {
         let srv = TestServer::new(ServerCfg {
             delay: Duration::from_millis(250),
-            fail_first_batch_once: false,
+            resps: vec![],
         })
         .await;
         let axiom = srv.mk_axiom(1, 1, 1);
@@ -1077,7 +1162,7 @@ mod tests {
     async fn ingest_retry_holds_sender_slot() {
         let srv = TestServer::new(ServerCfg {
             delay: Duration::ZERO,
-            fail_first_batch_once: true,
+            resps: vec![StubResp::Http500],
         })
         .await;
         let axiom = srv.mk_axiom(8, 1, 1);
@@ -1092,12 +1177,76 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn ingest_shutdown_flushes_partial_batch() {
+    async fn ingest_retries_malformed_success_body() {
         let srv = TestServer::new(ServerCfg {
             delay: Duration::ZERO,
-            fail_first_batch_once: false,
+            resps: vec![StubResp::OkBadJson],
         })
         .await;
+        let axiom = srv.mk_axiom(8, 1, 1);
+
+        send_evts(&axiom, 1).await;
+        let obs = srv.finish(axiom).await;
+
+        assert_eq!(obs.reqs.len(), 2);
+        assert_eq!(obs.reqs[0].start_seq, 0);
+        assert_eq!(obs.reqs[1].start_seq, 0);
+    }
+
+    #[derive(Clone, Copy)]
+    enum MaybeBadEvt {
+        Good(u64),
+        Bad,
+    }
+
+    impl serde::Serialize for MaybeBadEvt {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Good(seq) => TestEvt { seq: *seq }.serialize(serializer),
+                Self::Bad => Err(serde::ser::Error::custom("boom")),
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ingest_drops_bad_batch_and_keeps_running() {
+        let srv =
+            TestServer::new(ServerCfg { delay: Duration::ZERO, resps: vec![] })
+                .await;
+        let axiom = init(Config {
+            evt_que_len: 8,
+            service_name: "test-service",
+            base_url: format!("http://{}", srv.addr).parse().unwrap(),
+            api_key: "test-key",
+            dataset_id: "test",
+            collect_target: 2,
+            collect_timeout: Duration::from_secs(30),
+            sender_pool_size: 1,
+        });
+
+        axiom.evt_tx.send(Event::Extra(MaybeBadEvt::Good(0))).await.unwrap();
+        axiom.evt_tx.send(Event::Extra(MaybeBadEvt::Bad)).await.unwrap();
+        axiom.evt_tx.send(Event::Extra(MaybeBadEvt::Good(2))).await.unwrap();
+        axiom.evt_tx.send(Event::Extra(MaybeBadEvt::Good(3))).await.unwrap();
+        axiom.deinit().await;
+
+        let _ = srv.shutdown_tx.send(());
+        srv.server.await.unwrap();
+        let obs = srv.stub.obs.lock().unwrap();
+
+        assert_eq!(obs.reqs.len(), 1);
+        assert_eq!(obs.reqs[0].start_seq, 2);
+        assert_eq!(obs.reqs[0].evts, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ingest_shutdown_flushes_partial_batch() {
+        let srv =
+            TestServer::new(ServerCfg { delay: Duration::ZERO, resps: vec![] })
+                .await;
         let axiom = srv.mk_axiom(8, 4, 1);
 
         send_evts(&axiom, 3).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //!         dataset: "example-dataset",
 //!         collect_target: 4 << 10,
 //!         collect_timeout: std::time::Duration::from_millis(500),
+//!         sender_pool_size: 1,
 //!     });
 //!
 //! // NOTE: can clone `axiom.evt_tx` and send custom events to it as long as they
@@ -55,6 +56,8 @@ pub struct Config<'a> {
     /// If we didn't collect up to target after this duratiom, timeout and send
     /// what we have.
     pub collect_timeout: std::time::Duration,
+    /// Max number of concurrent sender jobs.
+    pub sender_pool_size: usize,
 }
 pub struct Axiom<X: Send = Never> {
     // NOTE: ORER MATTERS. this sender needs to be dropped before _bg_handle
@@ -66,6 +69,10 @@ pub fn init<X>(cfg: Config) -> Axiom<X>
 where
     X: serde::Serialize + std::marker::Send + 'static,
 {
+    if cfg.sender_pool_size == 0 {
+        panic!("sender_pool_size must be > 0");
+    }
+
     let (evt_tx, mut evt_rx) = tokio::sync::mpsc::channel(cfg.evt_que_len);
 
     // NOTE: too much effort to bubble error here. this is run once on app init
@@ -100,142 +107,34 @@ where
 
     let rt = tokio::runtime::Handle::current();
     let bg_task = async move {
-        use std::ops::ControlFlow::{Break, Continue};
-
-        use bytes::BufMut as _;
-
-        let mut zstd_ctx = zstd::zstd_safe::CCtx::try_create().unwrap();
-
-        let mut body = bytes::BytesMut::with_capacity(2048);
-        let mut evts_buf = Vec::with_capacity(cfg.collect_target);
-        loop {
-            let mut evts_count = 0;
-            body.clear();
-            let mut body_writer = body.writer();
-
-            let mut encoder = zstd::Encoder::with_context(
-                &mut body_writer, //.
-                &mut zstd_ctx,
-            );
-
-            let mut rest = cfg.collect_target;
-            while evts_count == 0 {
-                match tokio::time::timeout(cfg.collect_timeout, async {
-                    while rest > 0 {
-                        evts_buf.clear();
-                        let read = evt_rx.recv_many(&mut evts_buf, rest).await;
-                        assert_eq!(read, evts_buf.len());
-                        if read == 0 {
-                            // Channel is closed
-                            if evts_count > 0 {
-                                // send what we have before shutting down
-                                return Continue(());
-                            }
-                            // shutdown
-                            return Break(());
-                        }
-                        rest -= read;
-                        evts_count += read;
-
-                        for evt in &evts_buf {
-                            use std::io::Write as _;
-                            // ND-json: newline delimited
-                            serde_json::to_writer(
-                                &mut encoder,
-                                &EventWrapper {
-                                    service: EventService {
-                                        name: cfg.service_name,
-                                    },
-                                    event: evt,
-                                },
-                            )
-                            .unwrap();
-                            encoder.write_all(b"\n").unwrap();
-                        }
-                    }
-                    assert!(evts_buf.len() == cfg.collect_target);
-                    Continue(())
-                })
-                .await
-                {
-                    // forward shutfown sentinel
-                    Ok(Break(())) => return,
-                    Ok(Continue(()))
-                    | Err(tokio::time::error::Elapsed { .. }) => {}
-                };
-            }
-            assert!(evts_count > 0);
-            assert!(evts_count <= cfg.collect_target);
-
-            encoder.finish().unwrap();
-            body = body_writer.into_inner();
-            let body_shared = body.freeze();
-
-            let mut backoff = std::time::Duration::from_millis(500);
-            let mut reached_max_retry = true;
-            const MAX_RETRIES: u16 = 100;
-            for i in 0..MAX_RETRIES {
-                let res = client
-                    .post(ingest_url.clone())
-                    .header(reqwest::header::AUTHORIZATION, &bearer)
-                    .header(reqwest::header::CONTENT_TYPE, "application/json")
-                    .header(reqwest::header::CONTENT_ENCODING, "zstd")
-                    .body(body_shared.clone())
-                    .send()
-                    .await
-                    // axiom returns 200 with an error summary. nothing
-                    // interesting in body for other codes
-                    .and_then(|resp| resp.error_for_status());
-                match res {
-                    Ok(resp) => {
-                        let status_raw = resp.bytes().await.unwrap();
-                        let status: IngestStatus =
-                            serde_json::from_slice(&status_raw).unwrap();
-                        if status.failed > 0 || !status.failures.is_empty() {
-                            tracing::error!(
-                                ?backoff,
-                                attempt = i,
-                                status=?status_raw,
-                                evts_count,
-                                "axiom reported ingest failures");
-                        } else {
-                            reached_max_retry = false;
-                            break;
-                        }
-                    }
-                    Err(err) => {
-                        tracing::error!(
-                            ?backoff,
-                            attempt = i,
-                            ?err,
-                            evts_count,
-                            "axiom request failed"
-                        );
-                    }
-                }
-                tokio::time::sleep(backoff).await;
-                backoff = backoff.mul_f32(1.5);
-            }
-            if reached_max_retry {
-                tracing::error!(
-                    max_retries = MAX_RETRIES,
-                    evts_count,
-                    "reached max retries for ingest batch. dropping events!"
-                );
-            }
-
-            // cross our fingers and hope reqwest didn't keep any refs to body.
-            body = body_shared.into();
+        let mut slots = Vec::with_capacity(cfg.sender_pool_size);
+        for _ in 0..cfg.sender_pool_size {
+            slots.push(SenderSlot::default());
         }
+        let slots: Box<[SenderSlot]> = slots.into_boxed_slice();
+        let (idle_tx, mut idle_rx) =
+            tokio::sync::mpsc::channel(cfg.sender_pool_size);
+
+        let coord = coord_task(
+            &mut evt_rx,
+            &mut idle_rx,
+            &slots,
+            cfg.collect_target,
+            cfg.collect_timeout,
+            cfg.service_name,
+        );
+        let senders = futures_util::future::join_all(
+            slots.iter().enumerate().map(|(id, slot)| {
+                sender_task(id, slot, &idle_tx, &client, &ingest_url, &bearer)
+            }),
+        );
+
+        let ((), _senders) = tokio::join!(coord, senders);
     };
-    let bg_task =
+    let bg_handle =
         rt.spawn(bg_task.with_subscriber(tracing_core::Dispatch::none()));
 
-    Axiom {
-        evt_tx: evt_tx.clone(),
-        bg_handle: Some(bg_task),
-        // _bg_handle: BgHandle { evt_tx: Some(evt_tx), handle: bg_task },
-    }
+    Axiom { evt_tx: evt_tx.clone(), bg_handle: Some(bg_handle) }
 }
 
 impl<X: Send> Axiom<X> {
@@ -566,6 +465,212 @@ struct EventService<'a> {
     name: &'a str,
 }
 
+#[derive(Default)]
+struct SenderSlot {
+    /// Set by the coordinator, taken by exactly one sender task.
+    state: tokio::sync::Mutex<SenderSlotState>,
+    /// Wake the sender task after publishing a blob or closure.
+    ready: tokio::sync::Notify,
+}
+
+#[derive(Default)]
+struct SenderSlotState {
+    blob: Option<BatchBlob>,
+    closed: bool,
+}
+
+struct BatchBlob {
+    body: bytes::Bytes,
+    evts_count: usize,
+}
+
+async fn sender_task(
+    id: usize,
+    slot: &SenderSlot,
+    idle_tx: &tokio::sync::mpsc::Sender<usize>,
+    client: &reqwest::Client,
+    ingest_url: &reqwest::Url,
+    bearer: &reqwest::header::HeaderValue,
+) {
+    loop {
+        if idle_tx.send(id).await.is_err() {
+            return;
+        }
+
+        slot.ready.notified().await;
+
+        let blob = {
+            let mut state = slot.state.lock().await;
+            match state.blob.take() {
+                Some(blob) => blob,
+                None if state.closed => return,
+                None => unreachable!(),
+            }
+        };
+        send_blob(client, ingest_url, bearer, blob).await;
+
+        if slot.state.lock().await.closed {
+            return;
+        }
+    }
+}
+
+async fn coord_task<X>(
+    evt_rx: &mut tokio::sync::mpsc::Receiver<Event<X>>,
+    idle_rx: &mut tokio::sync::mpsc::Receiver<usize>,
+    slots: &[SenderSlot],
+    collect_target: usize,
+    collect_timeout: std::time::Duration,
+    service_name: &'static str,
+) where
+    X: serde::Serialize + Send + 'static,
+{
+    use std::io::Write as _;
+    use std::ops::ControlFlow::{Break, Continue};
+
+    use bytes::BufMut as _;
+
+    let mut zstd_ctx = zstd::zstd_safe::CCtx::try_create().unwrap();
+    let mut body = bytes::BytesMut::with_capacity(2048);
+    let mut evts_buf = Vec::with_capacity(collect_target);
+    loop {
+        let mut evts_count = 0;
+
+        body.clear();
+        let mut body_writer = body.writer();
+        let mut encoder = zstd::Encoder::with_context(
+            &mut body_writer, //.
+            &mut zstd_ctx,
+        );
+
+        let mut rest = collect_target;
+        while evts_count == 0 {
+            match tokio::time::timeout(collect_timeout, async {
+                while rest > 0 {
+                    evts_buf.clear();
+                    let read = evt_rx.recv_many(&mut evts_buf, rest).await;
+                    assert_eq!(read, evts_buf.len());
+                    if read == 0 {
+                        if evts_count == 0 {
+                            if evts_buf.is_empty() {
+                                return Break(());
+                            }
+                        }
+                        return Continue(());
+                    }
+                    rest -= read;
+                    evts_count += read;
+                    for evt in &evts_buf {
+                        serde_json::to_writer(&mut encoder, &EventWrapper {
+                            service: EventService { name: service_name },
+                            event: evt,
+                        })
+                        .unwrap();
+                        encoder.write_all(b"\n").unwrap();
+                    }
+                }
+                Continue(())
+            })
+            .await
+            {
+                Ok(Break(())) => {
+                    close_slots(slots).await;
+                    return;
+                }
+                Ok(Continue(())) | Err(tokio::time::error::Elapsed { .. }) => {}
+            };
+        }
+        assert!(evts_count > 0);
+        assert!(evts_count <= collect_target);
+
+        encoder.finish().unwrap();
+        body = body_writer.into_inner();
+        let blob = BatchBlob { body: body.split().freeze(), evts_count };
+
+        let id = idle_rx
+            .recv()
+            .await
+            .expect("sender tasks exited before coordinator");
+        let slot = &slots[id];
+        {
+            let mut state = slot.state.lock().await;
+            assert!(state.blob.is_none());
+            assert!(!state.closed);
+            state.blob = Some(blob);
+        }
+        slot.ready.notify_one();
+    }
+}
+
+async fn close_slots(slots: &[SenderSlot]) {
+    for slot in slots {
+        {
+            let mut state = slot.state.lock().await;
+            state.closed = true;
+        }
+        slot.ready.notify_one();
+    }
+}
+
+async fn send_blob(
+    client: &reqwest::Client,
+    ingest_url: &reqwest::Url,
+    bearer: &reqwest::header::HeaderValue,
+    blob: BatchBlob,
+) {
+    let mut backoff = std::time::Duration::from_millis(500);
+    let mut reached_max_retry = true;
+    const MAX_RETRIES: u16 = 100;
+    for i in 0..MAX_RETRIES {
+        let res = client
+            .post(ingest_url.clone())
+            .header(reqwest::header::AUTHORIZATION, bearer)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(reqwest::header::CONTENT_ENCODING, "zstd")
+            .body(blob.body.clone())
+            .send()
+            .await
+            .and_then(|resp| resp.error_for_status());
+        match res {
+            Ok(resp) => {
+                let status_raw = resp.bytes().await.unwrap();
+                let status: IngestStatus =
+                    serde_json::from_slice(&status_raw).unwrap();
+                if status.failed > 0 || !status.failures.is_empty() {
+                    tracing::error!(
+                        ?backoff,
+                        attempt = i,
+                        status=?status_raw,
+                        evts_count = blob.evts_count,
+                        "axiom reported ingest failures"
+                    );
+                } else {
+                    reached_max_retry = false;
+                    break;
+                }
+            }
+            Err(err) => {
+                tracing::error!(
+                    ?backoff,
+                    attempt = i,
+                    ?err,
+                    evts_count = blob.evts_count,
+                    "axiom request failed"
+                );
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = backoff.mul_f32(1.5);
+    }
+    if reached_max_retry {
+        tracing::error!(
+            max_retries = MAX_RETRIES,
+            evts_count = blob.evts_count,
+            "reached max retries for ingest batch. dropping events!"
+        );
+    }
+}
+
 fn ser_hex<const N: usize, S>(
     bytes: &[u8; N],
     serializer: S,
@@ -599,5 +704,304 @@ where
     match bytes {
         Some(bytes) => ser_hex(bytes, serializer),
         None => serializer.serialize_none(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        net::SocketAddr,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use axum::{
+        Router,
+        body::to_bytes,
+        extract::{Request, State},
+        response::IntoResponse,
+        routing::post,
+    };
+    use serde::{Deserialize, Serialize};
+
+    use super::{Config, Event, init};
+
+    #[derive(Clone, Copy)]
+    struct ServerCfg {
+        delay: Duration,
+        fail_first_batch_once: bool,
+    }
+
+    #[derive(Clone, Debug)]
+    struct ReqObs {
+        /// Lowest event seq seen in this ingest request body.
+        start_seq: u64,
+        /// Event count in this ingest request body.
+        evts: usize,
+    }
+
+    #[derive(Deserialize, Serialize)]
+    struct TestEvt {
+        seq: u64,
+    }
+
+    #[derive(Default)]
+    struct ServerObs {
+        /// Per-request attempt count for the retry test.
+        attempts: HashMap<u64, usize>,
+        /// Request log in arrival order.
+        reqs: Vec<ReqObs>,
+        /// Current concurrent requests inside the stub server.
+        in_flight: usize,
+        /// Peak concurrent requests inside the stub server.
+        max_in_flight: usize,
+    }
+
+    #[derive(Clone)]
+    struct StubServer {
+        /// Static behavior knobs for this server instance.
+        cfg: ServerCfg,
+        /// Mutable observations shared with the tests.
+        obs: Arc<Mutex<ServerObs>>,
+    }
+
+    struct RunObs {
+        /// Completed request log in arrival order.
+        reqs: Vec<ReqObs>,
+        /// Peak concurrent requests observed by the stub server.
+        max_in_flight: usize,
+    }
+
+    struct TestServer {
+        /// Bound local addr of the stub ingest server.
+        addr: SocketAddr,
+        /// Shared server state used both by the handler and the test.
+        stub: StubServer,
+        /// Triggers graceful server shutdown after the test run.
+        shutdown_tx: tokio::sync::oneshot::Sender<()>,
+        /// Join handle for the stub ingest server task.
+        server: tokio::task::JoinHandle<()>,
+    }
+
+    fn decode_req(body: bytes::Bytes) -> ReqObs {
+        let body =
+            zstd::stream::decode_all(std::io::Cursor::new(body.as_ref()))
+                .unwrap();
+
+        let mut start_seq = None;
+        let mut evts = 0usize;
+        for line in body.split(|byte| *byte == b'\n') {
+            if line.is_empty() {
+                continue;
+            }
+            let evt: TestEvt = serde_json::from_slice(line).unwrap();
+            start_seq.get_or_insert(evt.seq);
+            evts += 1;
+        }
+
+        ReqObs { start_seq: start_seq.unwrap(), evts }
+    }
+
+    fn record_req(stub: &StubServer, req: &ReqObs) -> bool {
+        let mut obs = stub.obs.lock().unwrap();
+        obs.in_flight += 1;
+        obs.max_in_flight = obs.max_in_flight.max(obs.in_flight);
+        obs.reqs.push(req.clone());
+
+        let attempt = obs.attempts.entry(req.start_seq).or_insert(0);
+        let should_fail = stub.cfg.fail_first_batch_once
+            && req.start_seq == 0
+            && *attempt == 0;
+        *attempt += 1;
+        should_fail
+    }
+
+    fn ingest_ok(evts: usize) -> impl IntoResponse {
+        axum::Json(serde_json::json!({
+            "failed": 0,
+            "ingested": evts,
+            "processedBytes": 0,
+            "failures": [],
+            "blocksCreated": null,
+            "walLength": null,
+        }))
+    }
+
+    async fn ingest(
+        State(stub): State<StubServer>,
+        req: Request,
+    ) -> impl IntoResponse {
+        let req =
+            decode_req(to_bytes(req.into_body(), usize::MAX).await.unwrap());
+        let should_fail = record_req(&stub, &req);
+
+        if stub.cfg.delay > Duration::ZERO {
+            tokio::time::sleep(stub.cfg.delay).await;
+        }
+
+        stub.obs.lock().unwrap().in_flight -= 1;
+
+        let status = if should_fail {
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        } else {
+            axum::http::StatusCode::OK
+        };
+        (status, ingest_ok(req.evts))
+    }
+
+    impl TestServer {
+        async fn new(cfg: ServerCfg) -> Self {
+            let stub = StubServer {
+                cfg,
+                obs: Arc::new(Mutex::new(ServerObs::default())),
+            };
+            let app = Router::new()
+                .route("/v1/datasets/test/ingest", post(ingest))
+                .with_state(stub.clone());
+            let listener = tokio::net::TcpListener::bind(SocketAddr::from((
+                [127, 0, 0, 1],
+                0,
+            )))
+            .await
+            .unwrap();
+            let addr = listener.local_addr().unwrap();
+            let (shutdown_tx, shutdown_rx) =
+                tokio::sync::oneshot::channel::<()>();
+            let server = tokio::spawn(async move {
+                axum::serve(listener, app)
+                    .with_graceful_shutdown(async move {
+                        let _ = shutdown_rx.await;
+                    })
+                    .await
+                    .unwrap();
+            });
+            Self { addr, stub, shutdown_tx, server }
+        }
+
+        fn mk_axiom(
+            &self,
+            evt_que_len: usize,
+            collect_target: usize,
+            sender_pool_size: usize,
+        ) -> super::Axiom<TestEvt> {
+            init(Config {
+                evt_que_len,
+                service_name: "test-service",
+                base_url: format!("http://{}", self.addr).parse().unwrap(),
+                api_key: "test-key",
+                dataset: "test",
+                collect_target,
+                collect_timeout: Duration::from_secs(30),
+                sender_pool_size,
+            })
+        }
+
+        async fn finish(self, axiom: super::Axiom<TestEvt>) -> RunObs {
+            axiom.deinit().await;
+            let _ = self.shutdown_tx.send(());
+            self.server.await.unwrap();
+
+            let obs = self.stub.obs.lock().unwrap();
+            RunObs { reqs: obs.reqs.clone(), max_in_flight: obs.max_in_flight }
+        }
+    }
+
+    async fn send_evts(axiom: &super::Axiom<TestEvt>, count: u64) {
+        for seq in 0..count {
+            axiom.evt_tx.send(Event::Extra(TestEvt { seq })).await.unwrap();
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ingest_sender_pool_1_preserves_request_order() {
+        let srv = TestServer::new(ServerCfg {
+            delay: Duration::from_millis(50),
+            fail_first_batch_once: false,
+        })
+        .await;
+        let axiom = srv.mk_axiom(8, 2, 1);
+
+        send_evts(&axiom, 4).await;
+        let obs = srv.finish(axiom).await;
+
+        assert_eq!(obs.reqs.len(), 2);
+        assert_eq!(obs.reqs[0].start_seq, 0);
+        assert_eq!(obs.reqs[1].start_seq, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ingest_sender_pool_gt_1_allows_concurrent_sends() {
+        let srv = TestServer::new(ServerCfg {
+            delay: Duration::from_millis(150),
+            fail_first_batch_once: false,
+        })
+        .await;
+        let axiom = srv.mk_axiom(8, 1, 2);
+
+        send_evts(&axiom, 4).await;
+        let obs = srv.finish(axiom).await;
+
+        assert!(obs.max_in_flight >= 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ingest_full_sender_pool_pushes_backpressure_upstream() {
+        let srv = TestServer::new(ServerCfg {
+            delay: Duration::from_millis(250),
+            fail_first_batch_once: false,
+        })
+        .await;
+        let axiom = srv.mk_axiom(1, 1, 1);
+
+        send_evts(&axiom, 3).await;
+
+        {
+            let evt_tx = axiom.evt_tx.clone();
+            let send = evt_tx.send(Event::Extra(TestEvt { seq: 3 }));
+            tokio::pin!(send);
+            assert!(
+                tokio::time::timeout(Duration::from_millis(50), &mut send)
+                    .await
+                    .is_err()
+            );
+        }
+
+        let _ = srv.finish(axiom).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ingest_retry_holds_sender_slot() {
+        let srv = TestServer::new(ServerCfg {
+            delay: Duration::ZERO,
+            fail_first_batch_once: true,
+        })
+        .await;
+        let axiom = srv.mk_axiom(8, 1, 1);
+
+        send_evts(&axiom, 2).await;
+        let obs = srv.finish(axiom).await;
+
+        assert_eq!(
+            obs.reqs.iter().map(|req| req.start_seq).collect::<Vec<_>>(),
+            vec![0, 0, 1]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ingest_shutdown_flushes_partial_batch() {
+        let srv = TestServer::new(ServerCfg {
+            delay: Duration::ZERO,
+            fail_first_batch_once: false,
+        })
+        .await;
+        let axiom = srv.mk_axiom(8, 4, 1);
+
+        send_evts(&axiom, 3).await;
+        let obs = srv.finish(axiom).await;
+
+        assert_eq!(obs.reqs.len(), 1);
+        assert_eq!(obs.reqs[0].start_seq, 0);
+        assert_eq!(obs.reqs[0].evts, 3);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,16 +774,20 @@ async fn send_blob(
                         Ok(status) => {
                             if status.failed > 0 || !status.failures.is_empty()
                             {
-                                log_retry!(
-                                    RetryErrKind::IngestFailed,
+                                // TODO: either get atomic ingest semantics
+                                // from axiom or track partial ingest and
+                                // resend only failed rows instead of dropping
+                                // the whole blob.
+                                tracing::error!(
                                     target: INTERNAL_TARGET,
-                                    ?backoff,
                                     attempt = attempts - 1,
+                                    failed = status.failed,
+                                    ingested = status.ingested,
                                     status=?status_raw,
                                     evts_count = blob.evts_count,
-                                    "axiom reported ingest failures"
+                                    "axiom reported partial ingest. dropping blob"
                                 );
-                                SendCtl::Retry
+                                SendCtl::Done
                             } else {
                                 SendCtl::Done
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@
 //!     tracing_axiom::init(tracing_axiom::Config {
 //!         evt_que_len: 4 << 10,
 //!         service_name: "example-service",
-//!         base_url: "https://api.axiom.co".parse().unwrap(),
+//!         base_url: "https://us-east-1.aws.edge.axiom.co".parse().unwrap(),
 //!         api_key: &api_key,
-//!         dataset: "example-dataset",
+//!         dataset_id: "example-dataset",
 //!         collect_target: 4 << 10,
 //!         collect_timeout: std::time::Duration::from_millis(500),
 //!         sender_pool_size: 1,
@@ -46,7 +46,7 @@ pub mod layer;
 pub struct Config<'a> {
     pub api_key: &'a str,
     pub base_url: reqwest::Url,
-    pub dataset: &'a str,
+    pub dataset_id: &'a str,
     /// Event queue length. Will start dropping events once this is full
     pub evt_que_len: usize,
     pub service_name: &'static str,
@@ -80,7 +80,7 @@ where
     //       parsing is deterministic and config shouldn't be dynamic
     let ingest_url = cfg
         .base_url
-        .join(&format!("v1/datasets/{}/ingest", cfg.dataset))
+        .join(&format!("v1/ingest/{}", cfg.dataset_id))
         .unwrap();
     let bearer = reqwest::header::HeaderValue::try_from(
         format!("Bearer {}", cfg.api_key), //.
@@ -298,7 +298,7 @@ impl From<tracing::Level> for Level {
     }
 }
 
-// https://axiom.co/docs/restapi/endpoints/ingestIntoDataset
+// https://axiom.co/docs/restapi/endpoints/ingestToDataset
 #[allow(dead_code)]
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -857,7 +857,7 @@ mod tests {
                 obs: Arc::new(Mutex::new(ServerObs::default())),
             };
             let app = Router::new()
-                .route("/v1/datasets/test/ingest", post(ingest))
+                .route("/v1/ingest/test", post(ingest))
                 .with_state(stub.clone());
             let listener = tokio::net::TcpListener::bind(SocketAddr::from((
                 [127, 0, 0, 1],
@@ -890,7 +890,7 @@ mod tests {
                 service_name: "test-service",
                 base_url: format!("http://{}", self.addr).parse().unwrap(),
                 api_key: "test-key",
-                dataset: "test",
+                dataset_id: "test",
                 collect_target,
                 collect_timeout: Duration::from_secs(30),
                 sender_pool_size,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -868,7 +868,7 @@ where
         buf[i * 2 + 1] = chr(b % 16);
     }
 
-    serializer.serialize_str(unsafe { str::from_utf8_unchecked(&buf) })
+    serializer.serialize_str(unsafe { str::from_utf8_unchecked(&buf[..N * 2]) })
 }
 fn ser_opt_hex<const N: usize, S>(
     bytes: &Option<[u8; N]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,11 @@ pub struct Config<'a> {
     pub evt_que_len: usize,
     pub service_name: &'static str,
 
-    /// Try to collect this many events before sending to axiom
+    /// Try to collect this many events before sending to axiom.
+    ///
+    /// Keep this at or below 10_000. Axiom-go's `IngestChannel` uses 10_000 as
+    /// its batch size cap:
+    /// https://github.com/axiomhq/axiom-go/blob/05ab863353532f691e2e46d72008d39897de3b6c/axiom/client.go#L444-L446
     pub collect_target: usize,
     /// If we didn't collect up to target after this duratiom, timeout and send
     /// what we have.


### PR DESCRIPTION
- new fixed-size sender pool after batch encode
- backpressure on all senders busy
- switch ingest to `/v1/ingest/{dataset_id}` https://axiom.co/docs/restapi/endpoints/ingestToDataset
- `dataset` -> `dataset_id`
- route internal logs via tracing without self-ingest loops
- impl pool sweep bench example
- retry bad success bodies instead of panicking
- drop bad encoded batches